### PR TITLE
Fix error on build after latest upgrade Knex 

### DIFF
--- a/src/knex.interfaces.ts
+++ b/src/knex.interfaces.ts
@@ -1,5 +1,6 @@
 import { ModuleMetadata, Type } from "@nestjs/common/interfaces";
-import * as knex from 'knex';
+// import * as knex from 'knex';
+import { Knex as knex } from 'knex';
 
 export type Knex = knex;
 export type Connection = Knex;


### PR DESCRIPTION
Cannot use namespace 'knex' as a type.
3 export declare type Knex = knex;
has no exported member 'Config'.

6     config: knex.Config;